### PR TITLE
feat: Add support for syncing sections of code with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## **Code Embedder**
 Seamlessly update code snippets in your **README** files! 🔄📝🚀
 
-[Description](#-description) • [Example](#-example) • [Setup](#-setup) • [Under the hood](#-under-the-hood)
+[Description](#-description) • [How it works](#-how-it-works) • [Example](#-example) • [Setup](#-setup) • [Under the hood](#-under-the-hood)
 </div>
 
 
@@ -15,6 +15,7 @@ Seamlessly update code snippets in your **README** files! 🔄📝🚀
 
 ✨ **Key features**
 - 🔄 **Automatic synchronization**: Keep your `README` code examples up-to-date without manual intervention.
+- 📝 **Section support**: Update specific sections of the script in the `README`.
 - 🛠️ **Easy setup**: Simply add the action to your GitHub workflow and format your `README` code blocks.
 - 🌐 **Language agnostic**: Works with any programming language or file type.
 
@@ -22,14 +23,33 @@ By using **Code Embedder**, you can focus on writing and updating your actual co
 
 ## 🔍 How it works
 
-The action looks for the following sections in the all markdown (`README`) files:
+The action looks for specific tags in all markdown (`README`) files, which indicate the script file path (and optionally the section to update), then it updates the code block sections in the `README` files with the content. The changes are then pushed to the repository 🚀.
+
+### 📄 **Full script** updates
+In the `README` (or other markdown) file, the full script is marked with the following tag:
 ````md
  ```language:path/to/script
  ```
 ````
-It updates the code snippets in `README` files with the content of the script located at `path/to/script` and pushes the changes to the repository 🚀.
+### 📂 **Section** updates
+In the `README` (or other markdown) file, the section of the script is marked with the following tag:
+````md
+ ```language:path/to/script:section_name
+ ```
+````
+You must also add the following comment tags in the script file `path/to/script`, where the section is located:
+```
+[Comment sign] code_embedder:section_name start
+...
+[Comment sign] code_embedder:section_name end
+```
+The comment sign is the one that is used in the script file, e.g. `#` for Python, or `//` for JavaScript. The `section_name` must be unique in the file, otherwise the action will not be able to identify the section.
 
-## 💡 Example
+
+
+## 💡 Examples
+
+### 📄 Full script update
 
 Let's say you have the following `README` file:
 ````md
@@ -56,7 +76,41 @@ This is a readme.
 print("Embedding successful")
 ```
 ````
-Once the content of the script located at `main.py` changes, the code block section will be updated in the `README` file with the next workflow run.
+With any changes to `main.py`, the code block section is updated in the `README` file with the next workflow run.
+
+### 📂 Section update
+
+Now we have the following `README` file:
+````md
+# README
+
+This is a readme.
+
+```python:main.py:A
+```
+````
+The `main.py` file contains the following code:
+```python
+print("Hello, world!")
+
+# code_embedder:A start
+print("Embedding successful")
+# code_embedder:A end
+```
+
+Once the workflow runs, the code block section will be updated in the `README` file with the content of the section `A` from the script located at `main.py` and pushed to the repository 🚀.
+
+````md
+# README
+
+This is a readme.
+
+```python:main.py:A
+print("Embedding successful")
+```
+````
+
+With any changes to the section `A` in `main.py`, the code block section is updated in the `README` file with the next workflow run.
 
 ## 🔧 Setup
 To use this action, you need to configure a yaml workflow file in `.github/workflows` folder (e.g. `.github/workflows/code-embedder.yaml`) with the following content:
@@ -86,6 +140,6 @@ You need to create a secret with write and repo permissions in the repository se
 
 ## 🔬 Under the hood
 This action performs the following steps:
-1. 🔎 Scans through the markdown (`README`) files to identify referenced script files.
+1. 🔎 Scans through the markdown (`README`) files to identify referenced script files (full script or section).
 1. 📝 Extracts the contents from those script files and updates the corresponding code blocks in the markdown (`README`) files.
 1. 🚀 Commits and pushes the updated documentation back to the repository.

--- a/src/code_embedding.py
+++ b/src/code_embedding.py
@@ -1,60 +1,20 @@
-import re
-from dataclasses import dataclass
-
 from loguru import logger
 
-
-@dataclass
-class ScriptMetadata:
-    readme_start: int
-    readme_end: int
-    path: str
-    content: str
-
-
-class ScriptPathExtractor:
-    def __init__(self) -> None:
-        self._code_block_start_regex = r"^```.*?:"
-        self._code_block_end = "```"
-        self._path_separator = ":"
-
-    def extract(self, readme_content: list[str]) -> list[ScriptMetadata]:
-        scripts = []
-        current_block = None
-
-        for row, line in enumerate(readme_content):
-            if self._is_code_block_start(line):
-                current_block = self._start_new_block(line, row)
-            elif self._is_code_block_end(line) and current_block:
-                scripts.append(self._finish_current_block(current_block, row))
-                current_block = None
-
-        return scripts
-
-    def _is_code_block_start(self, line: str) -> bool:
-        return re.search(self._code_block_start_regex, line) is not None
-
-    def _is_code_block_end(self, line: str) -> bool:
-        return line.strip() == self._code_block_end
-
-    def _start_new_block(self, line: str, row: int) -> dict:
-        path = line.split(self._path_separator)[-1].strip()
-        return {"start": row, "path": path}
-
-    def _finish_current_block(self, block: dict, end_row: int) -> ScriptMetadata:
-        return ScriptMetadata(
-            readme_start=block["start"], readme_end=end_row, path=block["path"], content=""
-        )
+from src.script_content_reader import ScriptContentReaderInterface
+from src.script_metadata import ScriptMetadata
+from src.script_metadata_extractor import ScriptMetadataExtractorInterface
 
 
 class CodeEmbedder:
     def __init__(
         self,
         readme_paths: list[str],
-        script_path_extractor: ScriptPathExtractor,
+        script_metadata_extractor: ScriptMetadataExtractorInterface,
+        script_content_reader: ScriptContentReaderInterface,
     ) -> None:
         self._readme_paths = readme_paths
-        self._script_path_extractor = script_path_extractor
+        self._script_metadata_extractor = script_metadata_extractor
+        self._script_content_reader = script_content_reader
 
     def __call__(self) -> None:
         for readme_path in self._readme_paths:
@@ -70,7 +30,8 @@ class CodeEmbedder:
         if not scripts:
             return
 
-        script_contents = self._read_script_content(scripts=scripts)
+        script_contents = self._script_content_reader.read(scripts=scripts)
+
         self._update_readme(
             script_contents=script_contents,
             readme_content=readme_content,
@@ -88,7 +49,7 @@ class CodeEmbedder:
     def _extract_scripts(
         self, readme_content: list[str], readme_path: str
     ) -> list[ScriptMetadata] | None:
-        scripts = self._script_path_extractor.extract(readme_content=readme_content)
+        scripts = self._script_metadata_extractor.extract(readme_content=readme_content)
         if not scripts:
             logger.info(f"No script paths found in README in path {readme_path}. Skipping.")
             return None
@@ -97,21 +58,6 @@ class CodeEmbedder:
             {set(script.path for script in scripts)}"""
         )
         return scripts
-
-    def _read_script_content(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]:
-        script_contents: list[ScriptMetadata] = []
-
-        for script in scripts:
-            try:
-                with open(script.path) as script_file:
-                    script.content = script_file.read()
-
-                script_contents.append(script)
-
-            except FileNotFoundError:
-                logger.error(f"Error: {script.path} not found. Skipping.")
-
-        return script_contents
 
     def _update_readme(
         self,
@@ -122,7 +68,7 @@ class CodeEmbedder:
         updated_readme = []
         readme_content_cursor = 0
 
-        for script in script_contents:
+        for script in sorted(script_contents, key=lambda x: x.readme_start):
             updated_readme += readme_content[readme_content_cursor : script.readme_start + 1]
             updated_readme += script.content + "\n"
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,9 @@ import argparse
 
 from loguru import logger
 
-from src.code_embedding import CodeEmbedder, ScriptPathExtractor
+from src.code_embedding import CodeEmbedder
+from src.script_content_reader import ScriptContentReader
+from src.script_metadata_extractor import ScriptMetadataExtractor
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -11,10 +13,12 @@ parser.add_argument(
 args = parser.parse_args()
 
 if __name__ == "__main__":
-    script_path_extractor = ScriptPathExtractor()
+    script_metadata_extractor = ScriptMetadataExtractor()
+    script_content_reader = ScriptContentReader()
     code_embedder = CodeEmbedder(
         readme_paths=args.readme_paths,
-        script_path_extractor=script_path_extractor,
+        script_metadata_extractor=script_metadata_extractor,
+        script_content_reader=script_content_reader,
     )
     code_embedder()
     logger.info("Code Embedder finished successfully.")

--- a/src/script_content_reader.py
+++ b/src/script_content_reader.py
@@ -1,0 +1,83 @@
+import re
+from typing import Protocol
+
+from loguru import logger
+
+from src.script_metadata import ScriptMetadata
+
+
+class ScriptContentReaderInterface(Protocol):
+    def read(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]: ...
+
+
+class ScriptContentReader:
+    def __init__(self) -> None:
+        self._section_start_regex = r".*code_embedder:.*start"
+        self._section_end_regex = r".*code_embedder:.*end"
+
+    def read(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]:
+        script_contents = self._read_full_script(scripts)
+        return self._process_scripts(script_contents)
+
+    def _read_full_script(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]:
+        script_contents: list[ScriptMetadata] = []
+
+        for script in scripts:
+            try:
+                with open(script.path) as script_file:
+                    script.content = script_file.read()
+
+                script_contents.append(script)
+
+            except FileNotFoundError:
+                logger.error(f"Error: {script.path} not found. Skipping.")
+
+        return script_contents
+
+    def _process_scripts(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]:
+        full_scripts = [script for script in scripts if not script.extraction_part]
+        scripts_with_sections = [script for script in scripts if script.extraction_part]
+
+        if scripts_with_sections:
+            scripts_with_sections = self._read_script_section(scripts_with_sections)
+
+        return full_scripts + scripts_with_sections
+
+    def _read_script_section(self, scripts: list[ScriptMetadata]) -> list[ScriptMetadata]:
+        return [
+            ScriptMetadata(
+                path=script.path,
+                extraction_part=script.extraction_part,
+                readme_start=script.readme_start,
+                readme_end=script.readme_end,
+                content=self._extract_section(script),
+            )
+            for script in scripts
+        ]
+
+    def _extract_section(self, script: ScriptMetadata) -> str:
+        lines = script.content.split("\n")
+        section_bounds = self._find_section_bounds(lines)
+
+        if not section_bounds:
+            logger.error(f"Section {script.extraction_part} not found in {script.path}")
+            return ""
+
+        start, end = section_bounds
+        return "\n".join(lines[start:end])
+
+    def _find_section_bounds(self, lines: list[str]) -> tuple[int, int] | None:
+        section_start = None
+        section_end = None
+
+        for i, line in enumerate(lines):
+            if re.search(self._section_start_regex, line):
+                section_start = i + 1
+            elif re.search(self._section_end_regex, line):
+                section_end = i
+                break
+
+        if section_start is None or section_end is None:
+            return None
+
+        return section_start, section_end

--- a/src/script_metadata.py
+++ b/src/script_metadata.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ScriptMetadata:
+    readme_start: int
+    readme_end: int
+    path: str
+    extraction_part: str | None = None  # None for full script, section_name for section
+    content: str = ""

--- a/src/script_metadata.py
+++ b/src/script_metadata.py
@@ -6,5 +6,5 @@ class ScriptMetadata:
     readme_start: int
     readme_end: int
     path: str
-    extraction_part: str | None = None  # None for full script, section_name for section
+    extraction_part: str | None = None
     content: str = ""

--- a/src/script_metadata_extractor.py
+++ b/src/script_metadata_extractor.py
@@ -1,0 +1,44 @@
+import re
+
+from src.script_metadata import ScriptMetadata
+
+
+class ScriptMetadataExtractor:
+    def __init__(self) -> None:
+        self._code_block_start_regex = r"^```.*?:"
+        self._code_block_end = "```"
+        self._path_separator = ":"
+
+    def extract(self, readme_content: list[str]) -> list[ScriptMetadata]:
+        scripts = []
+        current_block = None
+
+        for row, line in enumerate(readme_content):
+            if self._is_code_block_start(line):
+                current_block = self._start_new_block(line, row)
+            elif self._is_code_block_end(line) and current_block:
+                scripts.append(self._finish_current_block(current_block, row))
+                current_block = None
+
+        return scripts
+
+    def _is_code_block_start(self, line: str) -> bool:
+        return re.search(self._code_block_start_regex, line) is not None
+
+    def _is_code_block_end(self, line: str) -> bool:
+        return line.strip() == self._code_block_end
+
+    def _start_new_block(self, line: str, row: int) -> dict:
+        tag_items = line.split(self._path_separator)
+        path = tag_items[1].strip()
+        extraction_part = tag_items[2].strip() if len(tag_items) > 2 else None
+        return {"start": row, "path": path, "extraction_part": extraction_part}
+
+    def _finish_current_block(self, block: dict, end_row: int) -> ScriptMetadata:
+        return ScriptMetadata(
+            readme_start=block["start"],
+            readme_end=end_row,
+            path=block["path"],
+            extraction_part=block["extraction_part"],
+            content="",
+        )

--- a/src/script_metadata_extractor.py
+++ b/src/script_metadata_extractor.py
@@ -1,6 +1,11 @@
 import re
+from typing import Protocol
 
 from src.script_metadata import ScriptMetadata
+
+
+class ScriptMetadataExtractorInterface(Protocol):
+    def extract(self, readme_content: list[str]) -> list[ScriptMetadata]: ...
 
 
 class ScriptMetadataExtractor:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+from src.script_metadata import ScriptMetadata
+
+
+def create_script_metadata(
+    start: int, end: int, path: str, extraction_part: str | None = None
+) -> ScriptMetadata:
+    return ScriptMetadata(
+        readme_start=start,
+        readme_end=end,
+        path=path,
+        extraction_part=extraction_part,
+        content="",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,12 @@ from src.script_metadata import ScriptMetadata
 
 
 def create_script_metadata(
-    start: int, end: int, path: str, extraction_part: str | None = None
+    start: int, end: int, path: str, extraction_part: str | None = None, content: str = ""
 ) -> ScriptMetadata:
     return ScriptMetadata(
         readme_start=start,
         readme_end=end,
         path=path,
         extraction_part=extraction_part,
-        content="",
+        content=content,
     )

--- a/tests/data/example_section.py
+++ b/tests/data/example_section.py
@@ -1,0 +1,4 @@
+print("Hello, World!")
+# code_embedder:A start
+print("Printing only section A")
+# code_embedder:A end

--- a/tests/data/expected_readme1.md
+++ b/tests/data/expected_readme1.md
@@ -3,9 +3,8 @@
 This is a test readme.
 
 This will be filled:
-```python:tests/data/example.py
-print("Hello, World! from script")
-
+```python:tests/data/example_section.py:A
+print("Printing only section A")
 ```
 
 This won't be updated:

--- a/tests/data/readme1.md
+++ b/tests/data/readme1.md
@@ -3,7 +3,8 @@
 This is a test readme.
 
 This will be filled:
-```python:tests/data/example.py
+```python:tests/data/example_section.py:A
+print("Printing only section A")
 ```
 
 This won't be updated:

--- a/tests/test_code_embedding.py
+++ b/tests/test_code_embedding.py
@@ -1,87 +1,6 @@
-import pytest
-
-from src.code_embedding import CodeEmbedder, ScriptMetadata, ScriptPathExtractor
-
-
-@pytest.mark.parametrize(
-    "readme_content, expected",
-    [
-        (
-            ["```python:main.py", "print('Hello, World!')", "```"],
-            [ScriptMetadata(readme_start=0, readme_end=2, path="main.py", content="")],
-        ),
-        (["```", "print('Hello, World!')", "```"], []),
-        ([], []),
-        (["```python", "print('Hello, World!')", "```"], []),
-        (
-            [
-                "```python:example.py",
-                "import os",
-                "print('Hello, World!')",
-                "```",
-                "```",
-                "print('Do not replace')",
-                "```",
-            ],
-            [ScriptMetadata(readme_start=0, readme_end=3, path="example.py", content="")],
-        ),
-        (
-            [
-                "```python:main.py",
-                "print('Hello, World!')",
-                "```",
-                "```python:example.py",
-                "import os",
-                "print('Hello, World!')",
-                "```",
-                "```",
-                "print('Do not replace')",
-                "```",
-            ],
-            [
-                ScriptMetadata(readme_start=0, readme_end=2, path="main.py", content=""),
-                ScriptMetadata(readme_start=3, readme_end=6, path="example.py", content=""),
-            ],
-        ),
-    ],
-    ids=[
-        "one_tagged_script",
-        "one_untagged_script",
-        "empty_readme",
-        "one_untagged_script_language_specified",
-        "one_tagged_script_one_untagged_script",
-        "two_tagged_scripts_one_untagged_script",
-    ],
-)
-def test_script_path_extractor(
-    readme_content: list[str], expected: list[ScriptMetadata]
-) -> None:
-    script_path_extractor = ScriptPathExtractor()
-    result = script_path_extractor.extract(readme_content=readme_content)
-    assert result == expected
-
-
-def test_code_embedder_read_script_content() -> None:
-    code_embedder = CodeEmbedder(
-        readme_paths=["tests/data/readme.md"],
-        script_path_extractor=ScriptPathExtractor(),
-    )
-
-    scripts = code_embedder._read_script_content(
-        scripts=[
-            ScriptMetadata(
-                readme_start=6, readme_end=7, path="tests/data/example.py", content=""
-            )
-        ]
-    )
-    assert scripts == [
-        ScriptMetadata(
-            readme_start=6,
-            readme_end=7,
-            path="tests/data/example.py",
-            content='print("Hello, World! from script")\n',
-        )
-    ]
+from src.code_embedding import CodeEmbedder
+from src.script_content_reader import ScriptContentReader
+from src.script_metadata_extractor import ScriptMetadataExtractor
 
 
 def test_code_embedder(tmp_path) -> None:
@@ -104,7 +23,8 @@ def test_code_embedder(tmp_path) -> None:
 
     code_embedder = CodeEmbedder(
         readme_paths=[str(temp_readme_path) for temp_readme_path in temp_readme_paths],
-        script_path_extractor=ScriptPathExtractor(),
+        script_metadata_extractor=ScriptMetadataExtractor(),
+        script_content_reader=ScriptContentReader(),
     )
 
     code_embedder()

--- a/tests/test_script_content_reader.py
+++ b/tests/test_script_content_reader.py
@@ -1,0 +1,110 @@
+import pytest
+
+from src.script_content_reader import ScriptContentReader
+from src.script_metadata import ScriptMetadata
+
+
+@pytest.mark.parametrize(
+    "scripts, expected_scripts",
+    [
+        pytest.param(
+            [
+                ScriptMetadata(
+                    path="tests/data/example.py",
+                    extraction_part="",
+                    readme_start=0,
+                    readme_end=0,
+                    content="",
+                ),
+                ScriptMetadata(
+                    path="tests/data/example_section.py",
+                    extraction_part="A",
+                    readme_start=0,
+                    readme_end=0,
+                    content="",
+                ),
+            ],
+            [
+                ScriptMetadata(
+                    path="tests/data/example.py",
+                    extraction_part="",
+                    readme_start=0,
+                    readme_end=0,
+                    content='print("Hello, World! from script")\n',
+                ),
+                ScriptMetadata(
+                    path="tests/data/example_section.py",
+                    extraction_part="A",
+                    readme_start=0,
+                    readme_end=0,
+                    content=(
+                        'print("Hello, World!")\n'
+                        "# code_embedder:A start\n"
+                        'print("Printing only section A")\n'
+                        "# code_embedder:A end\n"
+                    ),
+                ),
+            ],
+            id="one_full_script_one_script_with_section",
+        ),
+    ],
+)
+def test_read_full_script(
+    scripts: list[ScriptMetadata], expected_scripts: list[ScriptMetadata]
+):
+    script_content_reader = ScriptContentReader()
+
+    assert script_content_reader._read_full_script(scripts) == expected_scripts
+
+
+@pytest.mark.parametrize(
+    "scripts, expected_scripts",
+    [
+        pytest.param(
+            [
+                ScriptMetadata(
+                    path="tests/data/example.py",
+                    extraction_part="no_section",
+                    readme_start=0,
+                    readme_end=0,
+                    content='print("Hello, World! from script")\n',
+                ),
+                ScriptMetadata(
+                    path="tests/data/example_section.py",
+                    extraction_part="A",
+                    readme_start=0,
+                    readme_end=0,
+                    content=(
+                        'print("Hello, World!")\n'
+                        "# code_embedder:A start\n"
+                        'print("Printing only section A")\n'
+                        "# code_embedder:A end\n"
+                    ),
+                ),
+            ],
+            [
+                ScriptMetadata(
+                    path="tests/data/example.py",
+                    extraction_part="no_section",
+                    readme_start=0,
+                    readme_end=0,
+                    content="",
+                ),
+                ScriptMetadata(
+                    path="tests/data/example_section.py",
+                    extraction_part="A",
+                    readme_start=0,
+                    readme_end=0,
+                    content='print("Printing only section A")',
+                ),
+            ],
+            id="one_full_script_one_script_with_section",
+        ),
+    ],
+)
+def test_read_script_section(
+    scripts: list[ScriptMetadata], expected_scripts: list[ScriptMetadata]
+):
+    script_content_reader = ScriptContentReader()
+
+    assert script_content_reader._read_script_section(scripts) == expected_scripts

--- a/tests/test_script_metadata_extractor.py
+++ b/tests/test_script_metadata_extractor.py
@@ -1,0 +1,157 @@
+import pytest
+
+from src.code_embedding import ScriptMetadata
+from src.script_metadata_extractor import ScriptMetadataExtractor
+
+
+@pytest.mark.parametrize(
+    "readme_content, expected",
+    [
+        (
+            ["```python:main.py", "print('Hello, World!')", "```"],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=2,
+                    path="main.py",
+                    extraction_part=None,
+                    content="",
+                )
+            ],
+        ),
+        (["```", "print('Hello, World!')", "```"], []),
+        ([], []),
+        (["```python", "print('Hello, World!')", "```"], []),
+        (
+            [
+                "```python:example.py",
+                "import os",
+                "print('Hello, World!')",
+                "```",
+                "```",
+                "print('Do not replace')",
+                "```",
+            ],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=3,
+                    path="example.py",
+                    extraction_part=None,
+                    content="",
+                )
+            ],
+        ),
+        (
+            [
+                "```python:main.py",
+                "print('Hello, World!')",
+                "```",
+                "```python:example.py",
+                "import os",
+                "print('Hello, World!')",
+                "```",
+                "```",
+                "print('Do not replace')",
+                "```",
+            ],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=2,
+                    path="main.py",
+                    extraction_part=None,
+                    content="",
+                ),
+                ScriptMetadata(
+                    readme_start=3,
+                    readme_end=6,
+                    path="example.py",
+                    extraction_part=None,
+                    content="",
+                ),
+            ],
+        ),
+        (
+            ["```python:main.py:section_name", "print('Hello, World!')", "```"],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=2,
+                    path="main.py",
+                    extraction_part="section_name",
+                    content="",
+                )
+            ],
+        ),
+        (
+            [
+                "```python:main.py:section_name",
+                "print('Hello, World!')",
+                "```",
+                "```python:example.py",
+                "print('Hello, World!')",
+                "```",
+            ],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=2,
+                    path="main.py",
+                    extraction_part="section_name",
+                    content="",
+                ),
+                ScriptMetadata(
+                    readme_start=3,
+                    readme_end=5,
+                    path="example.py",
+                    extraction_part=None,
+                    content="",
+                ),
+            ],
+        ),
+        (
+            [
+                "```python:main.py:A",
+                "print('Hello, World!')",
+                "```",
+                "```python:example.py:B",
+                "print('Hello, World!')",
+                "```",
+            ],
+            [
+                ScriptMetadata(
+                    readme_start=0,
+                    readme_end=2,
+                    path="main.py",
+                    extraction_part="A",
+                    content="",
+                ),
+                ScriptMetadata(
+                    readme_start=3,
+                    readme_end=5,
+                    path="example.py",
+                    extraction_part="B",
+                    content="",
+                ),
+            ],
+        ),
+    ],
+    ids=[
+        "one_tagged_script",
+        "one_untagged_script",
+        "empty_readme",
+        "one_untagged_script_language_specified",
+        "one_tagged_script_one_untagged_script",
+        "two_tagged_scripts_one_untagged_script",
+        "one_tagged_script_with_section_name",
+        "one_tagged_script_with_section_name_one_tagged_script",
+        "two_tagged_scripts_with_section_names",
+    ],
+)
+def test_script_path_extractor(
+    readme_content: list[str], expected: list[ScriptMetadata]
+) -> None:
+    script_metadata_extractor = ScriptMetadataExtractor()
+    result = script_metadata_extractor.extract(readme_content=readme_content)
+    assert result == expected

--- a/tests/test_script_metadata_extractor.py
+++ b/tests/test_script_metadata_extractor.py
@@ -1,154 +1,93 @@
 import pytest
 
-from src.code_embedding import ScriptMetadata
+from src.script_metadata import ScriptMetadata
 from src.script_metadata_extractor import ScriptMetadataExtractor
+from tests.conftest import create_script_metadata
+
+test_cases = [
+    pytest.param(
+        ["```python:main.py", "print('Hello, World!')", "```"],
+        [create_script_metadata(0, 2, "main.py")],
+        id="one_tagged_script",
+    ),
+    pytest.param(["```", "print('Hello, World!')", "```"], [], id="one_untagged_script"),
+    pytest.param([], [], id="empty_readme"),
+    pytest.param(
+        ["```javascript", "console.log('Hello, World!');", "```"],
+        [],
+        id="one_untagged_script_language_specified",
+    ),
+    pytest.param(
+        [
+            "```python:example.py",
+            "import os",
+            "print('Hello, World!')",
+            "```",
+            "```",
+            "print('Do not replace')",
+            "```",
+        ],
+        [create_script_metadata(0, 3, "example.py")],
+        id="one_tagged_script_one_untagged_script",
+    ),
+    pytest.param(
+        [
+            "```python:main.py",
+            "print('Hello, World!')",
+            "```",
+            "```python:example.py",
+            "import os",
+            "print('Hello, World!')",
+            "```",
+            "```",
+            "print('Do not replace')",
+            "```",
+        ],
+        [
+            create_script_metadata(0, 2, "main.py"),
+            create_script_metadata(3, 6, "example.py"),
+        ],
+        id="two_tagged_scripts_one_untagged_script",
+    ),
+    pytest.param(
+        ["```python:main.py:section_name", "print('Hello, World!')", "```"],
+        [create_script_metadata(0, 2, "main.py", "section_name")],
+        id="one_tagged_script_with_section_name",
+    ),
+    pytest.param(
+        [
+            "```python:main.py:section_name",
+            "print('Hello, World!')",
+            "```",
+            "```python:example.py",
+            "print('Hello, World!')",
+            "```",
+        ],
+        [
+            create_script_metadata(0, 2, "main.py", "section_name"),
+            create_script_metadata(3, 5, "example.py"),
+        ],
+        id="one_tagged_script_with_section_name_one_tagged_script",
+    ),
+    pytest.param(
+        [
+            "```python:main.py:A",
+            "print('Hello, World!')",
+            "```",
+            "```python:example.py:B",
+            "print('Hello, World!')",
+            "```",
+        ],
+        [
+            create_script_metadata(0, 2, "main.py", "A"),
+            create_script_metadata(3, 5, "example.py", "B"),
+        ],
+        id="two_tagged_scripts_with_section_names",
+    ),
+]
 
 
-@pytest.mark.parametrize(
-    "readme_content, expected",
-    [
-        (
-            ["```python:main.py", "print('Hello, World!')", "```"],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=2,
-                    path="main.py",
-                    extraction_part=None,
-                    content="",
-                )
-            ],
-        ),
-        (["```", "print('Hello, World!')", "```"], []),
-        ([], []),
-        (["```python", "print('Hello, World!')", "```"], []),
-        (
-            [
-                "```python:example.py",
-                "import os",
-                "print('Hello, World!')",
-                "```",
-                "```",
-                "print('Do not replace')",
-                "```",
-            ],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=3,
-                    path="example.py",
-                    extraction_part=None,
-                    content="",
-                )
-            ],
-        ),
-        (
-            [
-                "```python:main.py",
-                "print('Hello, World!')",
-                "```",
-                "```python:example.py",
-                "import os",
-                "print('Hello, World!')",
-                "```",
-                "```",
-                "print('Do not replace')",
-                "```",
-            ],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=2,
-                    path="main.py",
-                    extraction_part=None,
-                    content="",
-                ),
-                ScriptMetadata(
-                    readme_start=3,
-                    readme_end=6,
-                    path="example.py",
-                    extraction_part=None,
-                    content="",
-                ),
-            ],
-        ),
-        (
-            ["```python:main.py:section_name", "print('Hello, World!')", "```"],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=2,
-                    path="main.py",
-                    extraction_part="section_name",
-                    content="",
-                )
-            ],
-        ),
-        (
-            [
-                "```python:main.py:section_name",
-                "print('Hello, World!')",
-                "```",
-                "```python:example.py",
-                "print('Hello, World!')",
-                "```",
-            ],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=2,
-                    path="main.py",
-                    extraction_part="section_name",
-                    content="",
-                ),
-                ScriptMetadata(
-                    readme_start=3,
-                    readme_end=5,
-                    path="example.py",
-                    extraction_part=None,
-                    content="",
-                ),
-            ],
-        ),
-        (
-            [
-                "```python:main.py:A",
-                "print('Hello, World!')",
-                "```",
-                "```python:example.py:B",
-                "print('Hello, World!')",
-                "```",
-            ],
-            [
-                ScriptMetadata(
-                    readme_start=0,
-                    readme_end=2,
-                    path="main.py",
-                    extraction_part="A",
-                    content="",
-                ),
-                ScriptMetadata(
-                    readme_start=3,
-                    readme_end=5,
-                    path="example.py",
-                    extraction_part="B",
-                    content="",
-                ),
-            ],
-        ),
-    ],
-    ids=[
-        "one_tagged_script",
-        "one_untagged_script",
-        "empty_readme",
-        "one_untagged_script_language_specified",
-        "one_tagged_script_one_untagged_script",
-        "two_tagged_scripts_one_untagged_script",
-        "one_tagged_script_with_section_name",
-        "one_tagged_script_with_section_name_one_tagged_script",
-        "two_tagged_scripts_with_section_names",
-    ],
-)
+@pytest.mark.parametrize("readme_content, expected", test_cases)
 def test_script_path_extractor(
     readme_content: list[str], expected: list[ScriptMetadata]
 ) -> None:


### PR DESCRIPTION
This PR adds support for syncing only sections of code with README. Sections are depicted in README as 
````
  ```language:path/to/script:section_name
  ```
````
For example, we have the following `README` file:
````md
# README

This is a readme.

```python:main.py:A
```
````
The `main.py` file contains the following code:
```python
print("Hello, world!")

# code_embedder:A start
print("Embedding successful")
# code_embedder:A end
```

Once the workflow runs, the code block section will be updated in the `README` file with the content of the section `A` from the script located at `main.py` and pushed to the repository 🚀.

````md
# README

This is a readme.

```python:main.py:A
print("Embedding successful")
```
````

With any changes to the section `A` in `main.py`, the code block section is updated in the `README` file with the next workflow run.

Closes #9 