### PR TITLE
fix: Align Code-Embedder's commit message with conventional commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You need to create a secret with write and repo permissions in the repository se
 - **Read** access to actions variables, metadata and secrets.
 - **Read** and **Write** access to actions, contents (code), commit statuses, pull requests, and workflows.
 
-Also you need to add read and write permissions to workflows in your repository. You can find it under `Settings > Action > General > Workflow permissions`. 
+Also you need to add read and write permissions to workflows in your repository. You can find it under `Settings > Action > General > Workflow permissions`.
 
 ## 🔬 Under the hood
 This action performs the following steps:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ BRANCH_NAME=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
 
 git pull origin ${BRANCH_NAME}
 
-echo "Updating $README_PATHS with code snippets..."
+echo "Searching for code snippets in $README_PATHS..."
 
 poetry run python /app/src/main.py --readme-paths $README_PATHS
 
@@ -19,7 +19,7 @@ if [ -n "$(git status -s)" ]; then
     echo "Changes to commit..."
     git add $README_PATHS
     git diff --staged
-    git commit -m "Update $README_PATHS"
+    git commit -m "docs: Apply Code Embedder"
     git push origin ${BRANCH_NAME}
 else
     echo "No changes to commit."


### PR DESCRIPTION
This PR fixes Code-Embedder's commit message to align with conventional commit.

Closes #24 