### PR TITLE
fix: Fix default encoding when opening / writing files

### DIFF
--- a/code_embedder/code_embedding.py
+++ b/code_embedder/code_embedding.py
@@ -53,7 +53,7 @@ class CodeEmbedder:
         if not readme_path.endswith(".md"):
             raise ValueError("README path must end with .md")
 
-        with open(readme_path) as readme_file:
+        with open(readme_path, encoding="utf-8") as readme_file:
             return readme_file.readlines()
 
     def _extract_scripts(
@@ -86,5 +86,5 @@ class CodeEmbedder:
 
         updated_readme += readme_content[readme_content_cursor:]
 
-        with open(readme_path, "w") as readme_file:
+        with open(readme_path, "w", encoding="utf-8") as readme_file:
             readme_file.writelines(updated_readme)

--- a/code_embedder/script_content_reader.py
+++ b/code_embedder/script_content_reader.py
@@ -24,7 +24,7 @@ class ScriptContentReader:
 
         for script in scripts:
             try:
-                with open(script.path) as script_file:
+                with open(script.path, encoding="utf-8") as script_file:
                     script.content = script_file.read()
                     scripts_with_full_contents.append(script)
 

--- a/tests/test_code_embedding.py
+++ b/tests/test_code_embedding.py
@@ -43,7 +43,7 @@ def test_code_embedder(
 ) -> None:
     # Create a temporary copy of the original file
     temp_readme_path = tmp_path / "readme.md"
-    with open(before_code_embedding_path) as readme_file:
+    with open(before_code_embedding_path, encoding="utf-8") as readme_file:
         temp_readme_path.write_text(readme_file.read())
 
     code_embedder = CodeEmbedder(
@@ -55,10 +55,10 @@ def test_code_embedder(
 
     code_embedder()
 
-    with open(after_code_embedding_path) as expected_file:
+    with open(after_code_embedding_path, encoding="utf-8") as expected_file:
         expected_readme_content = expected_file.readlines()
 
-    with open(temp_readme_path) as updated_file:
+    with open(temp_readme_path, encoding="utf-8") as updated_file:
         updated_readme_content = updated_file.readlines()
 
     assert updated_readme_content == expected_readme_content


### PR DESCRIPTION
This PR fixes #50 - when opening files using `open()` function, it sets the encoding to the system's encoding. On windows it can be different than `utf-8`, which yielded to the issue opened in #50. Setting `encoding='utf-8'` fixes this issue. 